### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         node-version: ['20', '22']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -31,10 +31,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Deploy via Wrangler
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,10 +29,10 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -60,10 +60,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -93,7 +93,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Sync server.json's version with the version that was just
       # published to npm. Without this, workflow_dispatch with a custom
@@ -155,7 +155,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Prefer the workflow_dispatch version input over package.json.
       # The publish job bumps package.json with `npm version` only on its


### PR DESCRIPTION
## Why

GitHub forces JavaScript actions onto **Node 24 on 2026-06-16** and removes Node 20 from runners on 2026-09-16. Our workflows currently run `actions/checkout@v4`, `actions/setup-node@v4`, and `cloudflare/wrangler-action@v3` — all on the deprecated Node 20, which emits a deprecation annotation on every run.

## What

Bump to the latest majors, all of which declare `runs.using: node24`:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `cloudflare/wrangler-action` | v3 | **v4** |

13 `uses:` lines across `ci.yml`, `deploy-worker.yml`, `integration.yml`, `publish.yml`.

## Notes

- The matrix `node-version` values (`20`, `22`) are **untouched** — those are the project's own supported runtimes (`package.json` engines `>= 20`), unrelated to the action-runner deprecation.
- `wrangler-action@v4` keeps the `apiToken` / `accountId` inputs and the default `deploy` command, so `deploy-worker.yml` needs no other change (verified against its `action.yml`).
- Merging this exercises `wrangler-action@v4` end-to-end, since `deploy-worker.yml` triggers on changes to its own file. If the deploy were to fail, Cloudflare keeps the previously deployed version serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)