### PR TITLE
ci: teto de tempo no job de integração

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,12 @@ concurrency:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    # Teto de parede. O alvo de um destes contratos pode parar de responder
+    # sem fechar a conexão — descarte silencioso em firewall, medido no
+    # senado-br-mcp em 12/09/2026 — e aí cada requisição só morre no timeout
+    # dela, o job nunca falha sozinho e vai até as 6 h padrão do GitHub.
+    # Rodada real aqui leva no máximo ~2,5 min.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Fecha uma porta aberta, medida no irmão `senado-br-mcp-cloudflare` em 12/09/2026.

O alvo de um contrato pode parar de responder **sem fechar a conexão**. Naquele repo, 20 runners dispararam no mesmo instante contra o Senado: 18 conectaram e 2 não receberam nenhuma resposta de TCP, em nenhum endereço, enquanto buscavam um site de controle em menos de 60 ms. Descarte silencioso em firewall.

Nesse regime cada requisição só morre no timeout dela, o job nunca falha sozinho, e sem `timeout-minutes` ele caminha até as **6 horas** padrão do GitHub. Foi assim que o senado perdeu quatro noites.

Aqui **não há instância observada**: as últimas rodadas estão todas verdes, a mais longa em 138 s. É defesa, não conserto. O teto de 15 min dá seis vezes a folga da rodada real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArspxE1wayiqsNgDWq28bW